### PR TITLE
Fix broken cover image link

### DIFF
--- a/index.json
+++ b/index.json
@@ -90,7 +90,7 @@
     "commit": "d951351a75902336f7ab5d49f5f3e492a1dc312e"
   },
   {
-    "name": "Exactly Protocol Update",
+    "name": "Exactly Protocol",
     "date": "10/2022",
     "desc": "A review of the Exactly Protocol smart contracts update.",
     "auditors": ["Tanya Bushenyova", "Oleksii Matiiasevych", "Anderson Lee"],


### PR DESCRIPTION
@lastperson @sweetpea22 If we plan to list multiple audits in same directory. Maybe we should introduce new field "company" that can be used to link to cover image and allow us to put different audit names?